### PR TITLE
Twitch stream latency adjustments

### DIFF
--- a/src/streamWithWebcam.js
+++ b/src/streamWithWebcam.js
@@ -10,7 +10,8 @@ function main () {
   const FRAMERATE = config.twitch.stream.framerate
   const QUALITY = config.twitch.stream.qualityPreset // one of the many FFMPEG preset
 
-  const cmdString = `ffmpeg -f v4l2 -video_size 640x360 -i ${DISPLAY_DEVICE} -vcodec libx264 -r ${FRAMERATE} -pix_fmt yuv420p -preset ${QUALITY} -f flv "rtmp://${INGEST_SERVER}.twitch.tv/app/${STREAM_KEY}"`
+  const cmdString = `ffmpeg -f lavfi -i anullsrc=channel_layout=stereo:sample_rate=44100 -f v4l2 -video_size 640x480 -i ${DISPLAY_DEVICE} -vcodec libx264 -r ${FRAMERATE} -vf "scale=640:360" -g 30 -pix_fmt yuv420p -preset ${QUALITY} -f flv "rtmp://${INGEST_SERVER}.twitch.tv/app/${STREAM_KEY}"`
+
   exec(cmdString, (error, stdout, stderr) => {
     if (error) {
       console.log(`error: ${error.message}`)


### PR DESCRIPTION
This change improves latency on the Twitch stream. The most significant change is adding a dummy audio stream. Including an audio stream appears to halve latency.